### PR TITLE
Fix standalone attribute to render valid XML

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -67,10 +67,9 @@ impl XML {
     ///
     /// Consumes the XML object.
     pub fn generate<W: Write>(self, mut writer: W) -> Result<()> {
-        let standalone_attribute = if let Some(standalone) = self.standalone {
-            format!(r#" standalone="{}""#, standalone.to_string())
-        } else {
-            String::default()
+        let standalone_attribute = match self.standalone {
+            Some(_) => r#" standalone="yes""#.to_string(),
+            None => String::default(),
         };
 
         writeln!(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -209,7 +209,7 @@ fn test_complex_sorted_element_xml() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.1\" encoding=\"UTF-8\" standalone=\"true\"?>
+    let expected = "<?xml version=\"1.1\" encoding=\"UTF-8\" standalone=\"yes\"?>
 <house rooms=\"2\">
 \t<room size=\"27\" city=\"Paris\" number=\"1\">This is room number 1</room>
 \t<room city=\"LA\" number=\"2\" size=\"54\">This is room number 2</room>


### PR DESCRIPTION
Fix for #6

Using both `Some(true)` and `Some(false)` to indicate a **positive** intention and `None` to indicate **negative** intention feels wrong to me, but I decided not to implement that opinion here. 

This PR will leave the API alone and just make the XML output valid.