### PR TITLE
Add options to expand empty tags and to skip line breaks

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -28,6 +28,11 @@ pub struct XMLBuilder {
     ///
     /// Defaults to `false`.
     sort_attributes: bool,
+
+    /// Whether we want to break lines or not.
+    ///
+    /// Defaults to `true`.
+    break_lines: bool,
 }
 
 impl Default for XMLBuilder {
@@ -38,6 +43,7 @@ impl Default for XMLBuilder {
             standalone: None,
             indent: true,
             sort_attributes: false,
+            break_lines: true,
         }
     }
 }
@@ -91,6 +97,13 @@ impl XMLBuilder {
         self
     }
 
+    /// Sets whether to break lines.
+    pub fn break_lines(mut self, break_lines: bool) -> Self {
+        self.break_lines = break_lines;
+
+        self
+    }
+
     /// Builds a new XML structure by consuming self.
     pub fn build(self) -> XML {
         XML::new(
@@ -99,6 +112,7 @@ impl XMLBuilder {
             self.standalone,
             self.indent,
             self.sort_attributes,
+            self.break_lines,
         )
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,6 +33,11 @@ pub struct XMLBuilder {
     ///
     /// Defaults to `true`.
     break_lines: bool,
+
+    /// Whether we want to expand empty tags or not.
+    ///
+    /// Defaults to `false`.
+    expand_empty_tags: bool,
 }
 
 impl Default for XMLBuilder {
@@ -44,6 +49,7 @@ impl Default for XMLBuilder {
             indent: true,
             sort_attributes: false,
             break_lines: true,
+            expand_empty_tags: false,
         }
     }
 }
@@ -104,6 +110,13 @@ impl XMLBuilder {
         self
     }
 
+    /// Sets whether to expand empty tags.
+    pub fn expand_empty_tags(mut self, expand_empty_tags: bool) -> Self {
+        self.expand_empty_tags = expand_empty_tags;
+
+        self
+    }
+
     /// Builds a new XML structure by consuming self.
     pub fn build(self) -> XML {
         XML::new(
@@ -113,6 +126,7 @@ impl XMLBuilder {
             self.indent,
             self.sort_attributes,
             self.break_lines,
+            self.expand_empty_tags,
         )
     }
 }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -32,6 +32,11 @@ pub struct XML {
     /// Defaults to `true`.
     indent: bool,
 
+    /// Whether we want to break lines or not.
+    ///
+    /// Defaults to `true`.
+    break_lines: bool,
+
     /// The root XML element.
     root: Option<XMLElement>,
 }
@@ -43,6 +48,7 @@ impl XML {
         standalone: Option<bool>,
         indent: bool,
         sort_attributes: bool,
+        break_lines: bool,
     ) -> Self {
         Self {
             version,
@@ -50,6 +56,7 @@ impl XML {
             standalone,
             indent,
             sort_attributes,
+            break_lines,
             root: None,
         }
     }
@@ -71,16 +78,25 @@ impl XML {
             Some(_) => r#" standalone="yes""#.to_string(),
             None => String::default(),
         };
+        let suffix = match self.break_lines {
+            true => "\n",
+            false => "",
+        };
 
-        writeln!(
+        write!(
             writer,
-            r#"<?xml version="{}" encoding="{}"{}?>"#,
-            self.version, self.encoding, standalone_attribute
+            r#"<?xml version="{}" encoding="{}"{}?>{}"#,
+            self.version, self.encoding, standalone_attribute, suffix
         )?;
 
         // And then XML elements if present...
         if let Some(elem) = &self.root {
-            elem.render(&mut writer, self.sort_attributes, self.indent)?;
+            elem.render(
+                &mut writer,
+                self.sort_attributes,
+                self.indent,
+                self.break_lines,
+            )?;
         }
 
         Ok(())

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -37,6 +37,11 @@ pub struct XML {
     /// Defaults to `true`.
     break_lines: bool,
 
+    /// Whether we want to expand empty tags or not.
+    ///
+    /// Defaults to `false`.
+    expand_empty_tags: bool,
+
     /// The root XML element.
     root: Option<XMLElement>,
 }
@@ -49,6 +54,7 @@ impl XML {
         indent: bool,
         sort_attributes: bool,
         break_lines: bool,
+        expand_empty_tags: bool,
     ) -> Self {
         Self {
             version,
@@ -57,6 +63,7 @@ impl XML {
             indent,
             sort_attributes,
             break_lines,
+            expand_empty_tags,
             root: None,
         }
     }
@@ -96,6 +103,7 @@ impl XML {
                 self.sort_attributes,
                 self.indent,
                 self.break_lines,
+                self.expand_empty_tags,
             )?;
         }
 

--- a/src/xmlelement.rs
+++ b/src/xmlelement.rs
@@ -140,8 +140,9 @@ impl XMLElement {
         writer: &mut W,
         should_sort: bool,
         should_indent: bool,
+        should_break_lines: bool,
     ) -> Result<()> {
-        self.render_level(writer, 0, should_sort, should_indent)
+        self.render_level(writer, 0, should_sort, should_indent, should_break_lines)
     }
 
     /// Internal method rendering and indenting a XMLELement object
@@ -156,30 +157,45 @@ impl XMLElement {
         level: usize,
         should_sort: bool,
         should_indent: bool,
+        should_break_lines: bool,
     ) -> Result<()> {
         let indent = match should_indent {
             true => "\t".repeat(level),
             false => "".into(),
+        };
+        let suffix = match should_break_lines {
+            true => "\n",
+            false => "",
         };
 
         let attributes = self.attributes_as_string(should_sort);
 
         match &self.content {
             XMLElementContent::Empty => {
-                writeln!(writer, "{}<{}{} />", indent, self.name, attributes)?;
+                write!(
+                    writer,
+                    "{}<{}{} />{}",
+                    indent, self.name, attributes, suffix
+                )?;
             }
             XMLElementContent::Elements(elements) => {
-                writeln!(writer, "{}<{}{}>", indent, self.name, attributes)?;
+                write!(writer, "{}<{}{}>{}", indent, self.name, attributes, suffix)?;
                 for elem in elements {
-                    elem.render_level(writer, level + 1, should_sort, should_indent)?;
+                    elem.render_level(
+                        writer,
+                        level + 1,
+                        should_sort,
+                        should_indent,
+                        should_break_lines,
+                    )?;
                 }
-                writeln!(writer, "{}</{}>", indent, self.name)?;
+                write!(writer, "{}</{}>{}", indent, self.name, suffix)?;
             }
             XMLElementContent::Text(text) => {
-                writeln!(
+                write!(
                     writer,
-                    "{}<{}{}>{}</{}>",
-                    indent, self.name, attributes, text, self.name
+                    "{}<{}{}>{}</{}>{}",
+                    indent, self.name, attributes, text, self.name, suffix
                 )?;
             }
         };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -68,6 +68,25 @@ fn test_indent() {
 }
 
 #[test]
+fn test_line_breaks() {
+    let mut xml = XMLBuilder::new().break_lines(false).build();
+
+    let mut root = XMLElement::new("root");
+    let element = XMLElement::new("element");
+
+    root.add_child(element).unwrap();
+    xml.set_root_element(root);
+
+    let mut writer: Vec<u8> = Vec::new();
+    xml.generate(&mut writer).unwrap();
+
+    let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\t<element /></root>";
+    let res = std::str::from_utf8(&writer).unwrap();
+
+    assert_eq!(res, expected, "Both values does not match...");
+}
+
+#[test]
 fn test_xml_version_1_0() {
     let xml = XMLBuilder::new().version(XMLVersion::XML1_0).build();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,6 +87,27 @@ fn test_line_breaks() {
 }
 
 #[test]
+fn test_expand_empty_tags() {
+    let mut xml = XMLBuilder::new().expand_empty_tags(true).build();
+
+    let mut root = XMLElement::new("root");
+    let element = XMLElement::new("element");
+
+    root.add_child(element).unwrap();
+
+    xml.set_root_element(root);
+
+    let mut writer: Vec<u8> = Vec::new();
+    xml.generate(&mut writer).unwrap();
+
+    let expected =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n\t<element></element>\n</root>\n";
+    let res = std::str::from_utf8(&writer).unwrap();
+
+    assert_eq!(res, expected, "Both values does not match...");
+}
+
+#[test]
 fn test_xml_version_1_0() {
     let xml = XMLBuilder::new().version(XMLVersion::XML1_0).build();
 


### PR DESCRIPTION
While developing [playready-rs](https://github.com/dobo90/playready-rs), it came out that Microsoft server doesn't accept XML with empty tags (like `<emptytag />`) - they need to be expanded to `<emptytag></emptytag>`.

Moreover parts of XML content are signed. When signed content contains new line characters, server also doesn't accept the payload.

Thanks for the great crate! Is it possible to review those changes and if they are acceptable to merge them? I would love to publish playready-rs on [crates.io](https://crates.io) (but it's not possible as I'm using patched xml-builder).