### PR TITLE
Make XMLElement clonable

### DIFF
--- a/src/xmlcontent.rs
+++ b/src/xmlcontent.rs
@@ -1,6 +1,7 @@
 use crate::XMLElement;
 
 /// An enum value representing the types of XML contents
+#[derive(Clone)]
 pub(crate) enum XMLElementContent {
     /// No XML content.
     Empty,

--- a/src/xmlelement.rs
+++ b/src/xmlelement.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use crate::{escape_str, Result, XMLElementContent, XMLError};
 
 /// Structure representing an XML element field.
+#[derive(Clone)]
 pub struct XMLElement {
     /// The name of the XML element.
     name: String,


### PR DESCRIPTION
It may be desired to clone XMLElement when creating XML, such as repeating identical children in multiple parent tags.