### PR TITLE
Made Encoding Optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["LIAUD Corentin <corentinliaud26@gmail.com>"]
 categories = ["data-structures"]
 description = "Easy and highly-configurable XML builder/writer"
-edition = "2021"
+edition = "2024"
 keywords = ["xml"]
 license = "MIT"
 name = "xml-builder"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{XMLVersion, XML};
+use crate::{XML, XMLVersion};
 
 /// Builder structure used to generate a custom XML structure.
 pub struct XMLBuilder {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,7 @@ pub struct XMLBuilder {
     /// The encoding to set for the document.
     ///
     /// Defaults to `UTF-8`.
-    encoding: String,
+    encoding: Option<String>,
 
     /// XML standalone attribute.
     ///
@@ -44,7 +44,7 @@ impl Default for XMLBuilder {
     fn default() -> Self {
         Self {
             version: XMLVersion::XML1_0,
-            encoding: "UTF-8".into(),
+            encoding: None,
             standalone: None,
             indent: true,
             sort_attributes: false,
@@ -77,7 +77,7 @@ impl XMLBuilder {
     ///
     /// `encoding` - A String representing the encoding to use for the document.
     pub fn encoding(mut self, encoding: String) -> Self {
-        self.encoding = encoding;
+        self.encoding = Some(encoding);
 
         self
     }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -13,7 +13,7 @@ pub struct XML {
     /// The encoding to set for the document.
     ///
     /// Defaults to `UTF-8`.
-    encoding: String,
+    encoding: Option<String>,
 
     /// XML standalone attribute.
     ///
@@ -49,7 +49,7 @@ pub struct XML {
 impl XML {
     pub(crate) fn new(
         version: XMLVersion,
-        encoding: String,
+        encoding: Option<String>,
         standalone: Option<bool>,
         indent: bool,
         sort_attributes: bool,
@@ -81,20 +81,20 @@ impl XML {
     ///
     /// Consumes the XML object.
     pub fn generate<W: Write>(self, mut writer: W) -> Result<()> {
-        let standalone_attribute = match self.standalone {
-            Some(_) => r#" standalone="yes""#.to_string(),
-            None => String::default(),
-        };
-        let suffix = match self.break_lines {
-            true => "\n",
-            false => "",
+        write!(writer, r#"<?xml version="{}""#, self.version)?;
+
+        if let Some(encoding) = self.encoding {
+            write!(writer, r#" encoding="{}""#,  encoding)?;
+        }
+
+        if self.standalone.is_some() {
+            write!(writer, r#" standalone="yes""#)?;
         };
 
-        write!(
-            writer,
-            r#"<?xml version="{}" encoding="{}"{}?>{}"#,
-            self.version, self.encoding, standalone_attribute, suffix
-        )?;
+        write!(writer, "?>")?;
+        if self.break_lines {
+            write!(writer, "\n")?;
+        }
 
         // And then XML elements if present...
         if let Some(elem) = &self.root {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -10,9 +10,11 @@ pub struct XML {
     /// Defaults to `XML1.0`.
     version: XMLVersion,
 
-    /// The encoding to set for the document.
+    /// XML encoding attribute.
     ///
-    /// Defaults to `UTF-8`.
+    /// The optional encoding to set for the document.
+    ///
+    /// Defaults to `None`.
     encoding: Option<String>,
 
     /// XML standalone attribute.
@@ -81,19 +83,26 @@ impl XML {
     ///
     /// Consumes the XML object.
     pub fn generate<W: Write>(self, mut writer: W) -> Result<()> {
-        write!(writer, r#"<?xml version="{}""#, self.version)?;
+        write!(
+            writer,
+            r#"<?xml version="{}"{encoding}{standalone}?>"#,
+            self.version,
+            encoding = if let Some(encoding) = self.encoding {
+                format!(" encoding=\"{encoding}\"")
+            } else {
+                String::default()
+            },
+            standalone = if let Some(standalone) = self.standalone
+                && standalone
+            {
+                " standalone=\"yes\"".to_string()
+            } else {
+                String::default()
+            }
+        )?;
 
-        if let Some(encoding) = self.encoding {
-            write!(writer, r#" encoding="{}""#,  encoding)?;
-        }
-
-        if self.standalone.is_some() {
-            write!(writer, r#" standalone="yes""#)?;
-        };
-
-        write!(writer, "?>")?;
         if self.break_lines {
-            write!(writer, "\n")?;
+            writeln!(writer)?;
         }
 
         // And then XML elements if present...

--- a/src/xmlelement.rs
+++ b/src/xmlelement.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::{escape_str, Result, XMLElementContent, XMLError};
+use crate::{Result, XMLElementContent, XMLError, escape_str};
 
 /// Structure representing an XML element field.
 #[derive(Clone)]
@@ -73,7 +73,7 @@ impl XMLElement {
             XMLElementContent::Text(_) => {
                 return Err(XMLError::InsertError(
                     "Cannot insert child inside an element with text".into(),
-                ))
+                ));
             }
         };
 
@@ -95,7 +95,7 @@ impl XMLElement {
             _ => {
                 return Err(XMLError::InsertError(
                     "Cannot insert text in a non-empty element".into(),
-                ))
+                ));
             }
         };
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -100,8 +100,7 @@ fn test_expand_empty_tags() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected =
-        "<?xml version=\"1.0\"?>\n<root>\n\t<element></element>\n</root>\n";
+    let expected = "<?xml version=\"1.0\"?>\n<root>\n\t<element></element>\n</root>\n";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -22,7 +22,7 @@ fn test_xml_version() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.1\" encoding=\"UTF-8\"?>\n";
+    let expected = "<?xml version=\"1.1\"?>\n";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");
@@ -57,7 +57,7 @@ fn test_indent() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    let expected = "<?xml version=\"1.0\"?>
 <root>
 <indentation />
 <indentation />
@@ -80,7 +80,7 @@ fn test_line_breaks() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\t<element /></root>";
+    let expected = "<?xml version=\"1.0\"?><root>\t<element /></root>";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");
@@ -101,7 +101,7 @@ fn test_expand_empty_tags() {
     xml.generate(&mut writer).unwrap();
 
     let expected =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n\t<element></element>\n</root>\n";
+        "<?xml version=\"1.0\"?>\n<root>\n\t<element></element>\n</root>\n";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");
@@ -114,7 +114,7 @@ fn test_xml_version_1_0() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    let expected = "<?xml version=\"1.0\"?>\n";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");
@@ -127,7 +127,7 @@ fn test_xml_version_1_1() {
     let mut writer: Vec<u8> = Vec::new();
     xml.generate(&mut writer).unwrap();
 
-    let expected = "<?xml version=\"1.1\" encoding=\"UTF-8\"?>\n";
+    let expected = "<?xml version=\"1.1\"?>\n";
     let res = std::str::from_utf8(&writer).unwrap();
 
     assert_eq!(res, expected, "Both values does not match...");


### PR DESCRIPTION
Hi, i just discovered your lib and wanted to contribute to it (at least complete it for my use). This PR should fix #2 , However, i'm calling `write!` several times, as i find it easier to read when making it more modular. It can introduce a breaking change to existing code bases though, as i made `encoding` default to `None`.